### PR TITLE
vpc module v1.3.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3.0"
 
   required_providers {
-    aws   = ">= 3.59.0"
+    aws   = ">= 5.50.0"
     local = ">= 1.4"
   }
 }

--- a/networks.tf
+++ b/networks.tf
@@ -14,7 +14,7 @@ resource "aws_internet_gateway" "main" {
 resource "aws_eip" "main" {
   count = var.enabled && length(local.public_subnets) > 0 ? local.nat_gateway_count : 0
 
-  vpc = true
+  domain = "vpc"
 
   tags = merge(
     var.tags,

--- a/variables.tf
+++ b/variables.tf
@@ -37,16 +37,6 @@ variable "enable_dns_hostnames" {
   default = false
 }
 
-variable "enable_classiclink" {
-  type    = bool
-  default = false
-}
-
-variable "enable_classiclink_dns_support" {
-  type    = bool
-  default = false
-}
-
 variable "enable_dhcp_options" {
   type    = bool
   default = false

--- a/vpc.tf
+++ b/vpc.tf
@@ -2,12 +2,10 @@
 resource "aws_vpc" "main" {
   count = var.enabled && var.vpc_id == "" ? 1 : 0
 
-  cidr_block                     = cidrsubnet(var.cidr_block, 0, 0)
-  instance_tenancy               = var.instance_tenancy
-  enable_dns_support             = var.enable_dns_support
-  enable_dns_hostnames           = var.enable_dns_hostnames
-  enable_classiclink             = var.enable_classiclink
-  enable_classiclink_dns_support = var.enable_classiclink_dns_support
+  cidr_block           = cidrsubnet(var.cidr_block, 0, 0)
+  instance_tenancy     = var.instance_tenancy
+  enable_dns_support   = var.enable_dns_support
+  enable_dns_hostnames = var.enable_dns_hostnames
   tags = merge(
     local.tags,
     {


### PR DESCRIPTION
updated aws provider to be min 5.50.0.
vpc classiclink is retired, removed.
option vpc in aws_eip changed to domain.

	modified:   main.tf
	modified:   networks.tf
	modified:   variables.tf
	modified:   vpc.tf